### PR TITLE
Compute display name using component name

### DIFF
--- a/spec/fluxo_react_connect_stores_spec.js
+++ b/spec/fluxo_react_connect_stores_spec.js
@@ -3,12 +3,16 @@ describe("FluxoReactConnectStores", function () {
     var person = new Fluxo.Store({ name: "Samuel" });
 
     var Component = React.createClass({
+      displayName: "Component",
+
       render: function() {
         return React.createElement("p", null, this.props.person.name);
       }
     });
 
     Component = FluxoReactConnectStores(Component, { person: person });
+
+    expect(Component.displayName).to.be.eql("FluxoReactConnectStores(Component)");
 
     var shallowRenderer = React.addons.TestUtils.createRenderer();
 

--- a/src/fluxo_react_connect_stores.js
+++ b/src/fluxo_react_connect_stores.js
@@ -26,6 +26,8 @@
   return function (Component, stores) {
     /** @lends Fluxo.ConnectStores */
     return React.createClass({
+      displayName: "FluxoReactConnectStores(" + Component.displayName + ")",
+
       storesOnChangeCancelers: [],
 
       getInitialState: function() {


### PR DESCRIPTION
This will show the connected component with a better name intead of no
display name on react developer tools.
